### PR TITLE
fix: ordered-prow-config 1.17

### DIFF
--- a/ci-operator/jobs/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.17-postsubmits.yaml
+++ b/ci-operator/jobs/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.17-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     always_run: true
     branches:
     - ^rhoam-release-v1\.17$
-    cluster: build01
+    cluster: build02
     decorate: true
     decoration_config:
       skip_cloning: true


### PR DESCRIPTION
https://github.com/openshift/release/pull/26032 is failing on `ci/prow/ordered-prow-config`

Running `make jobs` locally did not generate any changes but the failed prow job suggests these changes:
* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/26032/pull-ci-openshift-release-master-ordered-prow-config/1491091194254462976